### PR TITLE
Migrate to GitHub Actions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,9 +29,9 @@ jobs:
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key:
-          ${{ matrix.django-version }}-${{ matrix.python-version }}-v1-${{ hashFiles('**/setup.py') }}
+          ${{ matrix.python-version }}-v1-${{ hashFiles('**/setup.py') }}
         restore-keys: |
-          ${{ matrix.django-version }}-${{ matrix.python-version }}-v1-
+          ${{ matrix.python-version }}-v1-
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,48 @@
+name: Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        python-version: ['2.7', '3.5', '3.6']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Get pip cache dir
+      id: pip-cache
+      run: |
+        echo "::set-output name=dir::$(pip cache dir)"
+
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: ${{ steps.pip-cache.outputs.dir }}
+        key:
+          ${{ matrix.django-version }}-${{ matrix.python-version }}-v1-${{ hashFiles('**/setup.py') }}
+        restore-keys: |
+          ${{ matrix.django-version }}-${{ matrix.python-version }}-v1-
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade tox tox-gh-actions
+
+    - name: Tox tests
+      run: |
+        tox -v
+
+    - name: Upload coverage
+      uses: codecov/codecov-action@v1
+      with:
+        name: Python ${{ matrix.python-version }}

--- a/requirements/test-ci.txt
+++ b/requirements/test-ci.txt
@@ -1,2 +1,1 @@
-pytest-cov==2.5.1
-codecov==2.0.11
+pytest-cov

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,4 +1,4 @@
 case>=1.3.1
 pytest>=3.0
-pytest-django==3.1.2
+pytest-django
 pytz>dev

--- a/tests/unit/test_camera.py
+++ b/tests/unit/test_camera.py
@@ -62,8 +62,9 @@ class test_Camera:
             worker.event('heartbeat', t, t, {})
         self.state.workers[worker.hostname] = worker
         assert (
-            self.cam.get_heartbeat(worker) ==
-            make_aware(datetime.fromtimestamp(t3))
+            self.cam.get_heartbeat(worker) == make_aware(
+                datetime.fromtimestamp(t3)
+            )
         )
 
     def test_handle_worker(self):
@@ -140,24 +141,28 @@ class test_Camera:
             task.event('received', tstamp, tstamp, {})
             mt = self.cam.handle_task((task.uuid, task))
             assert (
-                mt.tstamp ==
-                datetime(2016, 6, 1, 15, 0, 0, tzinfo=timezone.utc)
+                mt.tstamp == datetime(
+                    2016, 6, 1, 15, 0, 0, tzinfo=timezone.utc
+                )
             )
             assert (
-                mt.eta ==
-                datetime(2016, 6, 1, 15, 16, 17, 654321, tzinfo=timezone.utc)
+                mt.eta == datetime(
+                    2016, 6, 1, 15, 16, 17, 654321, tzinfo=timezone.utc
+                )
             )
             assert (
-                mt.expires ==
-                datetime(2016, 7, 1, 12, 16, 17, 765432, tzinfo=timezone.utc)
+                mt.expires == datetime(
+                    2016, 7, 1, 12, 16, 17, 765432, tzinfo=timezone.utc
+                )
             )
 
             task = self.create_task(worker, eta='2016-06-04T15:16:17.654321')
             task.event('received', tstamp, tstamp, {})
             mt = self.cam.handle_task((task.uuid, task))
             assert (
-                mt.eta ==
-                datetime(2016, 6, 4, 15, 16, 17, 654321, tzinfo=timezone.utc)
+                mt.eta == datetime(
+                    2016, 6, 4, 15, 16, 17, 654321, tzinfo=timezone.utc
+                )
             )
 
         with override_settings(USE_TZ=False, TIME_ZONE='Europe/Helsinki'):

--- a/tests/unit/test_camera.py
+++ b/tests/unit/test_camera.py
@@ -28,8 +28,8 @@ def Event(*args, **kwargs):
     return _Event(*args, **kwargs)
 
 
-@pytest.mark.django_db
 @pytest.mark.usefixtures('depends_on_current_app')
+@pytest.mark.django_db
 class test_Camera:
     Camera = camera.Camera
 

--- a/tests/unit/test_camera.py
+++ b/tests/unit/test_camera.py
@@ -28,7 +28,7 @@ def Event(*args, **kwargs):
     return _Event(*args, **kwargs)
 
 
-@pytest.mark.django_db()
+@pytest.mark.django_db
 @pytest.mark.usefixtures('depends_on_current_app')
 class test_Camera:
     Camera = camera.Camera

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,9 @@ envlist =
 
 [gh-actions]
 python =
-  2.7: py27, apicheck, builddocs, flake8, flakeplus, linkcheck, pydocstyle
+  2.7: py27, apicheck, flake8, flakeplus, linkcheck, pydocstyle
   3.5: py35
-  3.6: py36
+  3.6: py36, builddocs
 
 [testenv]
 sitepackages = False

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,7 @@ deps=
     flake8,flakeplus,manifest,pydocstyle,readme: -r{toxinidir}/requirements/pkgutils.txt
 
 commands =
-    tests: py.test -xv --cov=django_celery_monitor --cov-report=term --cov-report=xml --no-cov-on-fail []
+    tests: pytest -xv --cov=django_celery_monitor --cov-report=term --cov-report=xml --no-cov-on-fail []
     apicheck: sphinx-build -W -b apicheck -d {envtmpdir}/doctrees docs docs/_build/apicheck
     builddocs: sphinx-build -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
     flake8: flake8 {toxinidir}/django_celery_monitor {toxinidir}/tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    tests-py{py,27,35}-dj{18,19,110}
+    tests-py{py,27,35}-dj111
     tests-py36-dj111
     apicheck
     builddocs
@@ -23,9 +23,6 @@ deps=
     -r{toxinidir}/requirements/test.txt
     -r{toxinidir}/requirements/test-ci.txt
 
-    dj18: django>=1.8,<1.9
-    dj19: django>=1.9,<1.10
-    dj110: django>=1.10,<1.11
     dj111: django>=1.11,<2
 
     apicheck,builddocs,linkcheck: -r{toxinidir}/requirements/docs.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    tests-py{py,27,34,35}-dj{18,19,110}
+    tests-py{py,27,35}-dj{18,19,110}
     tests-py36-dj111
     apicheck
     builddocs
@@ -10,12 +10,11 @@ envlist =
     pydocstyle
     readme
 
-[travis]
+[gh-actions]
 python =
   2.7: py27, apicheck, builddocs, flake8, flakeplus, linkcheck, pydocstyle
-
-[travis:after]
-travis = python: 3.5
+  3.5: py35
+  3.6: py36
 
 [testenv]
 sitepackages = False

--- a/tox.ini
+++ b/tox.ini
@@ -12,9 +12,9 @@ envlist =
 
 [gh-actions]
 python =
-  2.7: py27, apicheck, flake8, flakeplus, linkcheck, pydocstyle
+  2.7: py27, flake8, flakeplus, pydocstyle
   3.5: py35
-  3.6: py36, builddocs
+  3.6: py36, apicheck, builddocs, linkcheck
 
 [testenv]
 sitepackages = False


### PR DESCRIPTION
Travis CI has a new pricing model which places limits on open source.

* https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
* https://www.jeffgeerling.com/blog/2020/travis-cis-new-pricing-plan-threw-wrench-my-open-source-works

Many projects are moving to GitHub Actions instead, including Jazzband projects:

* https://github.com/orgs/jazzband/projects/1
* https://github.com/jazzband-roadies/help/issues/206

This is based on https://github.com/jazzband/contextlib2/pull/26.

It drops support for Python 3.4 because GitHub Actions doesn't fully support it. It's EOL anyway.


TODO:

* [x] @jezdez to add `JAZZBAND_RELEASE_KEY` to the repo secrets.